### PR TITLE
UserIdを追加できるようにする

### DIFF
--- a/app/src/main/java/jp/co/yahoo/appfeedback/sample/MainActivity.java
+++ b/app/src/main/java/jp/co/yahoo/appfeedback/sample/MainActivity.java
@@ -9,7 +9,7 @@ import jp.co.yahoo.appfeedback.core.AppFeedback;
 
 public class MainActivity extends AppCompatActivity {
 
-    private static final String SLACK_CHANNEL = "CEJ4RQF6D";
+    private static final String SLACK_CHANNEL = "";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -18,8 +18,9 @@ public class MainActivity extends AppCompatActivity {
 
         // Externalで起動するパターン
         AppFeedback.start(this,
-                           BuildConfig.APP_FEEDBACK_SDK_SLACK_TOKEN,
-                           SLACK_CHANNEL);
+                           "",
+                           SLACK_CHANNEL,
+                "1234567890");
 
         findViewById(R.id.main_second).setOnClickListener(new View.OnClickListener() {
             @Override

--- a/sdk/src/main/java/jp/co/yahoo/appfeedback/core/AppFeedback.java
+++ b/sdk/src/main/java/jp/co/yahoo/appfeedback/core/AppFeedback.java
@@ -23,6 +23,8 @@ public class AppFeedback {
     private static boolean canUseMediaProjectionAPI = true;
     private static Intent mediaProjectionData = null;
 
+    private static String userId = null;
+
     /**
      * AppFeedbackSDKを初期化するための関数<br>
      * eventIdを指定しないので、internalで起動
@@ -41,6 +43,18 @@ public class AppFeedback {
      * @param slackChannel 投稿先の Channel ID
      */
     public static void start(Activity activity, String token, String slackChannel) {
+        start(activity, token, slackChannel, "");
+    }
+
+    /**
+     * AppFeedbackSDKを初期化するための関数<br>
+     * アプリが最初に立ち上げるActivity内で呼び出す<br>
+     * @param activity SDKを初期化するActivity
+     * @param token Slack Token
+     * @param slackChannel 投稿先の Channel ID
+     * @param userId NPのUser ID
+     */
+    public static void start(Activity activity, String token, String slackChannel, String userId) {
 
         if(appFeedbackContext != null) {
             // アプリケーション起動時以外のタイミングでは呼び出されてもスルーする
@@ -54,6 +68,7 @@ public class AppFeedback {
 
         AppFeedback.token = token;
         AppFeedback.slackChannel = slackChannel;
+        AppFeedback.userId = userId;
 
         appFeedbackContext = new AppFeedbackContext(activity);
 
@@ -83,6 +98,14 @@ public class AppFeedback {
     static void setMediaProjection(Intent mediaProjectionData, boolean canUseMediaProjectionAPI) {
         AppFeedback.mediaProjectionData = mediaProjectionData;
         AppFeedback.canUseMediaProjectionAPI = canUseMediaProjectionAPI;
+    }
+
+    /**
+     * UserIdを返す
+     * @return userId
+     */
+    static String getUserId() {
+        return AppFeedback.userId;
     }
 
     /**
@@ -136,5 +159,6 @@ public class AppFeedback {
         token = null;
         slackChannel = null;
         appFeedbackContext = null;
+        userId = null;
     }
 }

--- a/sdk/src/main/java/jp/co/yahoo/appfeedback/core/FeedbackActivity.java
+++ b/sdk/src/main/java/jp/co/yahoo/appfeedback/core/FeedbackActivity.java
@@ -323,6 +323,7 @@ public class FeedbackActivity extends Activity {
             new PostSlack(AppFeedback.getSlackApiUrl(),
                     this, AppFeedback.getSlackChannel(),
                     AppFeedback.getToken(),
+                    AppFeedback.getUserId(),
                     content).executeAsync(new SlackAPIHandler(this, this.sendingLabel));
 
         } catch (Exception e) {

--- a/sdk/src/main/java/jp/co/yahoo/appfeedback/core/api/PostSlack.java
+++ b/sdk/src/main/java/jp/co/yahoo/appfeedback/core/api/PostSlack.java
@@ -20,14 +20,16 @@ public class PostSlack extends API {
     private final String channel;
     private final String token;
     private final FeedbackContent content;
+    private final String userId;
 
-    public PostSlack(String apiUrl, Context context, String channel, String token, FeedbackContent content) {
+    public PostSlack(String apiUrl, Context context, String channel, String token, String userId, FeedbackContent content) {
         super(context);
 
         this.apiUrl = apiUrl;
         this.channel = channel;
         this.token= token;
         this.content = content;
+        this.userId = userId;
     }
 
     @Override
@@ -81,6 +83,10 @@ public class PostSlack extends API {
         comment.append("\n");
 
         comment.append("```");
+
+        comment.append("[UserId]\n");
+        comment.append(this.userId);
+        comment.append("\n\n");
 
         comment.append("[Message]\n");
         comment.append(this.content.message);

--- a/sdk/src/main/res/layout/appfeedback_activity_feedback.xml
+++ b/sdk/src/main/res/layout/appfeedback_activity_feedback.xml
@@ -182,7 +182,6 @@
                             android:layout_height="wrap_content"
                             android:layout_gravity="center_vertical"
                             android:layout_marginBottom="10dp"
-                            android:digits="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"
                             android:hint="@string/appfeedback_feedback_id"
                             android:inputType="text"
                             android:lines="1"


### PR DESCRIPTION
## 背景と目的
SlackへFeedBackする際、NPのUserIdも一緒に送る必要があるため。